### PR TITLE
Support generate python3 library from swig.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,7 @@ Debug
 ElkM1DesktopApp/obj
 ElkM1APITester/Debug
 ElkM1API/Debug
+ElkM1API/build
+ElkM1API/ElkM1API.py
+ElkM1API/swig_wrap.cpp
+ElkM1API/swig_wrap.h

--- a/ElkM1API/setup.py
+++ b/ElkM1API/setup.py
@@ -1,0 +1,30 @@
+#!/usr/bin/env python3
+
+from distutils.core import setup, Extension
+from textwrap import dedent
+
+elk_module = Extension(
+    '_ElkM1API',
+    sources=[
+        'ElkC1M1Tunnel.cpp',
+        'ElkM1AsciiAPI.cpp',
+        'ElkM1Connection.cpp',
+        'ElkM1Monitor.cpp',
+        'SwigCallbacks.cpp',
+        'swig.i',
+    ],
+    swig_opts=['-DELKM1API', '-c++', '-py3'],
+    extra_compile_args=['-std=c++11'])
+
+setup(
+    name='ElkM1API',
+    version='0.1',
+    author='ELK PRODUCTS, INC.',
+    license='MIT',
+    description=dedent("""\
+        ElkM1API is a wrapper for the many functions that the Elk ASCII \
+        protocol that allows it to request information in a familiar \
+        environment, with everything wrapped down to simple calls.\
+        """),
+    ext_modules=[elk_module],
+    py_modules=['ElkM1API'])


### PR DESCRIPTION
This supports the ability of generating a python3 library to communicate to the Elk M1.

### To install this python3 module:
```
cd ElkM1API
sudo python3 setup.py install
```

### To use with python3:
```
$ python3
Python 3.5.2 (default, Nov 17 2016, 17:05:23) 
[GCC 5.4.0 20160609] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> import ElkM1API
>>> 
```

I currently do not have a Elk M1 and cannot test the output. But it does compile on Ubuntu 16.04 and can be imported with python 3.5. Goal is to integrate this with [home-assistant.io](https://home-assistant.io/).